### PR TITLE
Allow flexible configuration and other commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM devopsfaith/krakend:latest
 
-LABEL maintainer="dortiz@krakend.io"
+LABEL maintainer="community@krakend.io"
 
 ENV KRAKEND_CONFIG krakend.json
+ENV USAGE_DISABLE 1
 
 ADD reflex /usr/bin/reflex
 ADD entrypoint.sh /

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # KrakenD Configuration Watcher
+A Docker image to reload KrakenD when the configuration in the disk changes.
 
-**WARNING** This is a development tool for configuration testing. **DON'T USE IN PRODUCTION**.
-
-This container allows you to monitor a KrakenD config file for changes and reload KrakenD with the new version.
+[Documentation](https://www.krakend.io/docs/developer/config-watcher/)
 
 ### Build
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,28 @@
 #!/bin/sh
+# Reruns a KrakenD command every time the configuration changes
+# Pass KRAKEND_CONFIG with the filename you want to use as the configuration
+# Pass KRAKEND_COMMAND if you want a different command than run
 
-KRAKEND_CFG=${KRAKEND_CONFIG:-krakend.json}
+KRAKEND_CONFIG=${KRAKEND_CONFIG:-krakend.json}
+
+# Default KrakenD command
+if [[ -z "${KRAKEND_COMMAND}" ]]; then
+    KRAKEND_COMMAND="run -c /etc/krakend/${KRAKEND_CONFIG} -d"
+fi
+
+echo "Watching changes on files /etc/krakend/${KRAKEND_CONFIG}"
 
 cd /etc/krakend
-/usr/bin/reflex -g "$KRAKEND_CFG" -s  -- /usr/bin/krakend run -c /etc/krakend/${KRAKEND_CFG} -d
+
+# Run without flexible configuration
+if [[ -z "${FC_ENABLE}" ]]; then
+  /usr/bin/reflex -g "*.*" -s  -- /usr/bin/krakend $KRAKEND_COMMAND
+else
+# Run with flexible configuration values in ENV
+	FC_ENABLE=1 \
+    FC_SETTINGS="$FC_SETTINGS" \
+    FC_PARTIALS="$FC_PARTIALS" \
+    FC_TEMPLATES="$FC_TEMPLATES" \
+    FC_OUT="$FC_OUT" \
+    /usr/bin/reflex -g "*.*" -s  -- /usr/bin/krakend $KRAKEND_COMMAND
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,25 +4,17 @@
 # Pass KRAKEND_COMMAND if you want a different command than run
 
 KRAKEND_CONFIG=${KRAKEND_CONFIG:-krakend.json}
+FC_OUT=${FC_OUT:-out.json}
 
 # Default KrakenD command
 if [[ -z "${KRAKEND_COMMAND}" ]]; then
     KRAKEND_COMMAND="run -c /etc/krakend/${KRAKEND_CONFIG} -d"
 fi
 
+
 echo "Watching changes on files /etc/krakend/${KRAKEND_CONFIG}"
 
 cd /etc/krakend
 
-# Run without flexible configuration
-if [[ -z "${FC_ENABLE}" ]]; then
-  /usr/bin/reflex -g "*.*" -s  -- /usr/bin/krakend $KRAKEND_COMMAND
-else
-# Run with flexible configuration values in ENV
-	FC_ENABLE=1 \
-    FC_SETTINGS="$FC_SETTINGS" \
-    FC_PARTIALS="$FC_PARTIALS" \
-    FC_TEMPLATES="$FC_TEMPLATES" \
-    FC_OUT="$FC_OUT" \
-    /usr/bin/reflex -g "*.*" -s  -- /usr/bin/krakend $KRAKEND_COMMAND
-fi
+
+/usr/bin/reflex -g "*.*" -G "$FC_OUT" -s  -- /usr/bin/krakend $KRAKEND_COMMAND


### PR DESCRIPTION
Changes introduced:
- Watches the entire `/etc/krakend` directory
- Allows passing a `KRAKEND_COMMAND` to modify the command. Useful to watch with `krakend check`.
- Enables Flexible configuration